### PR TITLE
feat(issuer-sdk): add getAllByIssuer method to fetch sessions by issuer

### DIFF
--- a/packages/ssi-issuer-sdk/src/lib/CredentialIssuer.ts
+++ b/packages/ssi-issuer-sdk/src/lib/CredentialIssuer.ts
@@ -173,6 +173,14 @@ export class CredentialIssuer {
   }
 
   /**
+   * Get all credential offer sessions by issuer
+   * @param issuerId
+   */
+  public async getAllSessionsByIssuer(issuerId:string):Promise<CredentialOfferSession[]> {
+    return this.sessionManager.getAllByIssuer(issuerId);
+  }
+
+  /**
    * Process notification from wallet
    * @param preAuthorizedCode Pre-authorized code
    * @param issuerState Issuer state for auth code flow

--- a/packages/ssi-issuer-sdk/src/lib/__tests__/CredentialIssuer.spec.ts
+++ b/packages/ssi-issuer-sdk/src/lib/__tests__/CredentialIssuer.spec.ts
@@ -116,6 +116,7 @@ describe('CredentialIssuer', () => {
       delete: jest.fn(),
       saveNonce: jest.fn(),
       getAll: jest.fn().mockResolvedValue([mockSession]),
+      getAllByIssuer:jest.fn().mockResolvedValue([mockSession]),
     };
 
     mockCredentialProcessor = {

--- a/packages/ssi-issuer-sdk/src/lib/interfaces/session-manager.ts
+++ b/packages/ssi-issuer-sdk/src/lib/interfaces/session-manager.ts
@@ -47,4 +47,9 @@ export interface ISessionManager {
    * Get all sessions
    */
   getAll(): Promise<CredentialOfferSession[]>;
+
+  /**
+   * Get All Sessions By Issuer
+   */
+  getAllByIssuer(issuerId: string): Promise<CredentialOfferSession[]>;
 }

--- a/packages/ssi-issuer-sdk/src/lib/services/IssuerSessionManager.ts
+++ b/packages/ssi-issuer-sdk/src/lib/services/IssuerSessionManager.ts
@@ -1,13 +1,13 @@
-import { CNonceState } from '../types/credential.js';
+import { CNonceState } from '../types/index.js';
 import { CredentialError, CredentialErrorCode } from '../types/errors.js';
 import { CredentialOfferSession } from '../types/session.js';
-import { ISessionManager, NonceUpdate } from '../interfaces/session-manager.js';
-import { IStorage } from '@blockialabs/ssi-storage';
+import { ISessionManager, NonceUpdate } from '../interfaces/index.js';
+import { IIssuerSessionStorage, IStorage } from '@blockialabs/ssi-storage';
 import { v4 as uuidv4 } from 'uuid';
 
 export class IssuerSessionManager implements ISessionManager {
   constructor(
-    private readonly sessionStorage: IStorage<CredentialOfferSession>,
+    private readonly sessionStorage: IIssuerSessionStorage<CredentialOfferSession>,
     private readonly nonceStorage: IStorage<CNonceState>,
   ) {}
 
@@ -103,9 +103,11 @@ export class IssuerSessionManager implements ISessionManager {
   async getAll(): Promise<CredentialOfferSession[]> {
     const keys = await this.sessionStorage.keys();
     const sessions = await Promise.all(keys.map((k: string) => this.sessionStorage.get(k)));
-    const filtered = sessions.filter((s): s is CredentialOfferSession => !!s);
+    return sessions.filter((s): s is CredentialOfferSession => !!s);
+  }
 
-    return filtered;
+  async getAllByIssuer(issuerId: string): Promise<CredentialOfferSession[]> {
+    return await this.sessionStorage.getAllByIssuer(issuerId);
   }
 
   private async saveSessionWithReferences(session: CredentialOfferSession): Promise<void> {

--- a/packages/ssi-storage/src/index.ts
+++ b/packages/ssi-storage/src/index.ts
@@ -7,3 +7,4 @@ export { InMemoryStorage } from './lib/implementations/InMemoryStorage.js';
 export type { IStorage } from './lib/interfaces/IStorage.js';
 export type { IStorageDriver } from './lib/interfaces/IStorageDriver.js';
 export type { IStorageOptions } from './lib/interfaces/IStorageOptions.js';
+export type {IIssuerSessionStorage} from "./lib/interfaces/IIssuerSessionStorage.js"

--- a/packages/ssi-storage/src/lib/interfaces/IIssuerSessionStorage.ts
+++ b/packages/ssi-storage/src/lib/interfaces/IIssuerSessionStorage.ts
@@ -1,0 +1,5 @@
+import { IStorage } from './IStorage.js';
+
+export interface IIssuerSessionStorage<T=unknown> extends IStorage<T>{
+  getAllByIssuer(issuerId: string): Promise<T[]>;
+}


### PR DESCRIPTION
- Added getAllByIssuer method in IssuerSessionManager to fetch all CredentialOfferSessions for a specific issuer.
- Extended ISessionManager and IIssuerSessionStorage interfaces to include getAllByIssuerId.
- Updated Jest mocks to support the new getAllByIssuer method for testing.

This change improves the package by allowing an issuer to fetch only their own credential sessions, rather than retrieving all sessions from the database.