### PR TITLE
refactor(sdk): allowing issuers to edit the credential subject and va…

### DIFF
--- a/packages/ssi-credentials/src/lib/types/operations.ts
+++ b/packages/ssi-credentials/src/lib/types/operations.ts
@@ -17,6 +17,8 @@ export interface IPrepareOptions {
   domain?: string;
   contextHashes?: Record<string, string>;
   credentialFormat?: CredentialFormatType;
+  credentialSubject?: Record<string, string>;
+  validUntil?: string;
 }
 
 export interface IIssueOptions extends IPrepareOptions {

--- a/packages/ssi-issuer-sdk/src/lib/ApprovalBuilder.ts
+++ b/packages/ssi-issuer-sdk/src/lib/ApprovalBuilder.ts
@@ -85,20 +85,28 @@ export class ApprovalBuilder {
           error_description: 'Invalid session state',
         };
       }
-
-      // 4. Complete credential issuance
+      // 4. Update the credentialSubject and the validUntil attribute of the request
+      if (this.completeOptions.credentialSubject) {
+        session.pendingCredential.credential.credentialSubject =
+          this.completeOptions.credentialSubject;
+      }
+      if (this.completeOptions.validUntil) {
+        session.pendingCredential.credential.validUntil = this.completeOptions.validUntil;
+      }
+      // 5. Complete credential issuance
       const signedCredential = await this.credentialProcessor.completeIssuance(
         session.pendingCredential,
         this.completeOptions as ICompleteOptions,
       );
 
-      // 5. Update session with issued credential
+      // 6. Update session with issued credential
       await this.sessionManager.createOrUpdate(session.id, {
         issuerState: IssueStatus.CREDENTIAL_ISSUED,
         credentialResponse: signedCredential,
+        pendingCredential:session.pendingCredential
       });
 
-      // 6. Return success response
+      // 7. Return success response
       return {
         credentials: [
           {

--- a/packages/ssi-verifier-sdk/src/lib/utils/ResponseValidator.ts
+++ b/packages/ssi-verifier-sdk/src/lib/utils/ResponseValidator.ts
@@ -227,7 +227,7 @@ export class ResponseValidator {
    */
   private static async verifyAllCredentials(
     credentialProcessor: CredentialProcessor,
-    vpToken: any,
+    vpToken: IVerifiablePresentation,
     options: VerificationOptions,
   ): Promise<EnhancedVerificationResult> {
     const errors: string[] = [];
@@ -268,10 +268,10 @@ export class ResponseValidator {
         }
 
         // Verify credential is not expired if requested
-        if (credential.expirationDate) {
-          const expirationDate = new Date(credential.expirationDate);
-          if (expirationDate < new Date()) {
-            credErrors.push(`Credential at index ${i} expired on ${expirationDate.toISOString()}`);
+        if (credential.validUntil) {
+          const validUntil = new Date(credential.validUntil);
+          if (validUntil < new Date()) {
+            credErrors.push(`Credential at index ${i} expired on ${validUntil.toISOString()}`);
           }
         }
 


### PR DESCRIPTION
This PR enables issuers to edit credential requests submitted by holders and introduces support for adding an expiration date to these requests. Previously, credential requests were immutable once submitted, limiting issuers’ ability to correct or update request details. With this change, issuers can now make necessary modifications and ensure credentials include a clear expiration timeline, and better management of issued credentials.